### PR TITLE
Dependency cooldown - 1 week

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,9 @@ dependencies = [
     "python-dateutil",   # dateutil - add explicitly
 ]
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [dependency-groups]
 dev = [
     "deptry>=0.25.1",


### PR DESCRIPTION
This tells uv to ignore any package version published less than 1 week ago, to mitigate supply-chain attacks for Python dependencies.  See [link](https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns) for more on this issue