### PR TITLE
added pre-commit hook ruff example

### DIFF
--- a/precommit_hooks_examples/README.md
+++ b/precommit_hooks_examples/README.md
@@ -1,0 +1,5 @@
+This directory can hold example pre-commit hooks scripts.  
+
+To use a given script, place it in your `.git/hooks/pre-commit/` directory (which is only local and not tracked by GitHub, hence this directory here to store them).
+
+**Note:** `git commit --no-verify` skips all hooks. Useful when you're mid-work and committing a checkpoint.

--- a/precommit_hooks_examples/run-ruff.sh
+++ b/precommit_hooks_examples/run-ruff.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Run ruff on committed file
+
+# possible modifications: could run ruff check --fix $STAGED so it auto-fixes what it can and only fails on things it can't fix automatically. Just be aware you'd then need to re-stage those files with git add.
+
+# Get only staged Python files
+#    diff --cached --name-only, lists only the files staged for the current commit
+#   --diff-filter=ACM limits to Added, Copied, and Modified files (skips deleted files, which ruff can't check anyway).
+STAGED=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+
+if [ -z "$STAGED" ]; then
+  exit 0
+fi
+
+# Run ruff on only those files
+ruff check $STAGED
+
+if [ $? -ne 0 ]; then
+  echo "ruff found issues. Fix them or use --no-verify to skip."
+  exit 1
+fi


### PR DESCRIPTION
Just added a directory with one example pre-commit hook.  If there are others, we can add them as well.  (The code there needs to be placed in a different directory -- as specified in the README)