### PR TITLE
Add CI workflow to run pytest on pull requests to main

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,28 @@
+name: Run pytest
+
+on:
+  # Run on pull requests...
+  pull_request:
+    # ...but only when the PR's target (base) branch is main.
+    branches:
+      - main
+
+jobs:
+  # This job is named "test" — that's the name that will show up as a required
+  # status check when configuring branch protection.
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the PR's code onto the runner so later steps can access it.
+      - uses: actions/checkout@v4
+      # Install uv (the Python package/dependency manager this project uses).
+      - uses: astral-sh/setup-uv@v6
+        with:
+          python-version: "3.12"
+
+      # Install all dependencies, including optional groups (scrape, data-manipulation, etc.)
+      # that the test suite needs but a plain "uv sync" would skip.
+      - run: uv sync --all-groups
+      # Run the test suite; if any test fails, this step (and the job) fails,
+      # which is what shows up as a red/failing status check on the PR.
+      - run: uv run pytest tests/

--- a/tests/test_database_helpers.py
+++ b/tests/test_database_helpers.py
@@ -424,16 +424,16 @@ def test_sanitize_table_name_replaces_double_quotes(raw: str, expected: str) -> 
 
 def test_speech_url_exists_in_db_returns_true_when_url_exists(tmp_path):
     """Test that speech_url_exists_in_db returns True when the given URL
-    is present in the speeches table.
+    is present in the texts table.
     """
     test_db_path = tmp_path / "test_speeches.db"
     conn = sqlite3.connect(test_db_path)
     cursor = conn.cursor()
 
     try:
-        cursor.execute("CREATE TABLE speeches (id INTEGER PRIMARY KEY, url TEXT);")
+        cursor.execute("CREATE TABLE texts (id INTEGER PRIMARY KEY, url TEXT);")
         cursor.executemany(
-            "INSERT INTO speeches (url) VALUES (?);",
+            "INSERT INTO texts (url) VALUES (?);",
             [
                 ("https://example.com/s1",),
                 ("https://example.com/s2",),
@@ -447,16 +447,16 @@ def test_speech_url_exists_in_db_returns_true_when_url_exists(tmp_path):
 
 def test_speech_url_exists_in_db_returns_false_when_url_missing(tmp_path):
     """Test that speech_url_exists_in_db returns False when the given URL
-    is not present in the speeches table.
+    is not present in the texts table.
     """
     test_db_path = tmp_path / "test_speeches.db"
     conn = sqlite3.connect(test_db_path)
     cursor = conn.cursor()
 
     try:
-        cursor.execute("CREATE TABLE speeches (id INTEGER PRIMARY KEY, url TEXT);")
+        cursor.execute("CREATE TABLE texts (id INTEGER PRIMARY KEY, url TEXT);")
         cursor.executemany(
-            "INSERT INTO speeches (url) VALUES (?);",
+            "INSERT INTO texts (url) VALUES (?);",
             [
                 ("https://example.com/s1",),
             ],
@@ -468,7 +468,7 @@ def test_speech_url_exists_in_db_returns_false_when_url_missing(tmp_path):
         conn.close()
 
 def test_speech_url_exists_in_db_returns_false_when_speeches_table_missing(tmp_path):
-    """Test that speech_url_exists_in_db returns False when the speeches table
+    """Test that speech_url_exists_in_db returns False when the texts table
     does not exist (should be handled by the function's exception guard).
     """
     test_db_path = tmp_path / "test_missing_table.db"
@@ -476,7 +476,7 @@ def test_speech_url_exists_in_db_returns_false_when_speeches_table_missing(tmp_p
     cursor = conn.cursor()
 
     try:
-        # Deliberately do NOT create speeches table.
+        # Deliberately do NOT create texts table.
         cursor.execute("CREATE TABLE other_table (id INTEGER PRIMARY KEY, url TEXT);")
         conn.commit()
 
@@ -502,9 +502,9 @@ def test_speech_url_exists_in_db_handles_multiple_rows_same_url(tmp_path):
     cursor = conn.cursor()
 
     try:
-        cursor.execute("CREATE TABLE speeches (id INTEGER PRIMARY KEY, url TEXT);")
+        cursor.execute("CREATE TABLE texts (id INTEGER PRIMARY KEY, url TEXT);")
         cursor.executemany(
-            "INSERT INTO speeches (url) VALUES (?);",
+            "INSERT INTO texts (url) VALUES (?);",
             [
                 ("https://example.com/dup",),
                 ("https://example.com/dup",),
@@ -525,8 +525,8 @@ def test_speech_url_exists_in_db_returns_false_when_url_is_none(tmp_path):
     cursor = conn.cursor()
 
     try:
-        cursor.execute("CREATE TABLE speeches (id INTEGER PRIMARY KEY, url TEXT);")
-        cursor.execute("INSERT INTO speeches (url) VALUES (?);", ("https://example.com/s1",))
+        cursor.execute("CREATE TABLE texts (id INTEGER PRIMARY KEY, url TEXT);")
+        cursor.execute("INSERT INTO texts (url) VALUES (?);", ("https://example.com/s1",))
         conn.commit()
 
         assert db_module.speech_url_exists_in_db(test_db_path, None) is False


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow (`.github/workflows/pytest.yml`) that runs the
`pytest` test suite automatically on every pull request targeting `main`.

Also fixes 2 pre-existing failing tests in `tests/test_database_helpers.py`
(`test_speech_url_exists_in_db_returns_true_when_url_exists` and
`..._handles_multiple_rows_same_url`) — they were creating a table named
`speeches`, but `speech_url_exists_in_db()` queries the `texts` table (the
actual schema). Fixed the tests to match the real schema.

## Why
We want CI to catch failing tests before they land on `main`, and eventually
to block merging PRs that break the test suite.

## ⚠️ Action needed from a repo admin
This workflow only *reports* pass/fail status — it does not block merging by
itself. To actually make "tests must pass" a requirement for merging into
`main`, someone with **admin** access to the repo needs to:

1. Go to **Settings → Branches** (repo settings, not this PR)
2. Click **Add branch protection rule** (or edit the existing one for `main`)
3. Set **Branch name pattern** to `main`
4. Enable **Require status checks to pass before merging**
5. In the search box for status checks, select **`test`** (the job defined
   in this workflow — it needs to have run at least once, e.g. on this PR,
   before it shows up in the list)
6. Save changes

Once that's done, any future PR with a failing test will be blocked from
merging into `main` until it's fixed.